### PR TITLE
Update the bundle to be compatible to Pimcore X

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     }
   ],
   "require": {
-    "php": ">=7.0",
-    "pimcore/pimcore": ">=6.8"
+    "php": "^8.0",
+    "pimcore/pimcore": ">=10.0.8"
   },
   "autoload": {
     "psr-4": {

--- a/src/QuickTranslateBundle/Controller/DocumentController.php
+++ b/src/QuickTranslateBundle/Controller/DocumentController.php
@@ -147,15 +147,11 @@ class DocumentController extends FrontendController
             if ($docType) {
                 $createValues['template'] = $docType->getTemplate();
                 $createValues['controller'] = $docType->getController();
-                $createValues['action'] = $docType->getAction();
-                $createValues['module'] = $docType->getModule();
                 $createValues['legacy'] = $docType->getLegacy();
             } elseif ($request->get('translationsBaseDocument')) {
                 $translationsBaseDocument = Document::getById($request->get('translationsBaseDocument'));
                 $createValues['template'] = $translationsBaseDocument->getTemplate();
                 $createValues['controller'] = $translationsBaseDocument->getController();
-                $createValues['action'] = $translationsBaseDocument->getAction();
-                $createValues['module'] = $translationsBaseDocument->getModule();
             } elseif ($request->get('type') == 'page' || $request->get('type') == 'snippet' || $request->get('type') == 'email') {
                 $createValues += Tool::getRoutingDefaults();
             }

--- a/src/QuickTranslateBundle/Controller/DocumentController.php
+++ b/src/QuickTranslateBundle/Controller/DocumentController.php
@@ -57,12 +57,12 @@ class DocumentController extends FrontendController
 
             $brickName = $request->get("brickName");
             $elems = $db->fetchAll("SELECT name, type, data
-                                        FROM documents_elements
+                                        FROM documents_editables
                                         WHERE documentId=" . $document->getId() . " AND (type='input' OR type='textarea' OR type='wysiwyg') AND name LIKE '" . $brickName . "%'");
 
             if ($elems == null && $document->getContentMasterDocumentId() != null) {
                 $elems = $db->fetchAll("SELECT name, type, data
-                                        FROM documents_elements
+                                        FROM documents_editables
                                         WHERE documentId=" . $document->getContentMasterDocumentId() . " AND (type='input' OR type='textarea' OR type='wysiwyg') AND name LIKE '" . $brickName . "%'");
             }
 
@@ -72,12 +72,12 @@ class DocumentController extends FrontendController
         } else {
 
             $elems = $db->fetchAll("SELECT name, type, data
-                                        FROM documents_elements
+                                        FROM documents_editables
                                         WHERE documentId=" . $request->get("id") . " AND (type='input' OR type='textarea' OR type='wysiwyg')");
 
             if ($elems == null && $document->getContentMasterDocumentId() != null) {
                 $elems = $db->fetchAll("SELECT name, type, data
-                                        FROM documents_elements
+                                        FROM documents_editables
                                         WHERE documentId=" . $document->getContentMasterDocumentId() . " AND (type='input' OR type='textarea' OR type='wysiwyg')");
             }
         }
@@ -103,9 +103,9 @@ class DocumentController extends FrontendController
         $elements = json_decode($request->get("elements"), true);
         $document = Document::getById($request->get("id"));
 
-        $oldElements = $document->getElements();
+        $oldElements = $document->getEditables();
 
-        $document->setElements($oldElements);
+        $document->setEditables($oldElements);
 
         foreach ($elements as $key => $element) {
 
@@ -223,12 +223,12 @@ class DocumentController extends FrontendController
                     $translateDoc = Document::getById($request->get("translateDocId"));
 
 
-                    $newDoc->setElements($translateDoc->getElements());
+                    $newDoc->setEditables($translateDoc->getEditables());
 
                     $elements = json_decode($request->get("elements"), true);
 
                     foreach ($elements as $key => $element) {
-                        $newDoc->setRawElement($key, $element["type"], $element["data"]);
+                        $newDoc->setRawEditable($key, $element["type"], $element["data"]);
                     }
 
                     $newDoc->save();

--- a/src/QuickTranslateBundle/DependencyInjection/Configuration.php
+++ b/src/QuickTranslateBundle/DependencyInjection/Configuration.php
@@ -25,8 +25,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('asioso_quick_translate');
+        $treeBuilder = new TreeBuilder('asioso_quick_translate');
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/src/QuickTranslateBundle/Resources/config/pimcore/routing.yml
+++ b/src/QuickTranslateBundle/Resources/config/pimcore/routing.yml
@@ -1,24 +1,24 @@
 asioso_quick_translate_object:
     path:     /asioso_quick_translate_object
-    defaults: { _controller: QuickTranslateBundle:Object:translateObject }
+    controller: Asioso\QuickTranslateBundle\Controller\ObjectController::translateObjectAction
 
 asioso_quick_translate_document:
     path:     /asioso_quick_translate_document
-    defaults: { _controller: QuickTranslateBundle:Document:saveDocument }
+    controller: Asioso\QuickTranslateBundle\Controller\DocumentController::saveDocumentAction
 
 asioso_quick_translate_brick:
     path:     /asioso_quick_translate_brick
-    defaults: { _controller: QuickTranslateBundle:Document:saveBrick }
+    controller: Asioso\QuickTranslateBundle\Controller\DocumentController::saveBrickAction
 
 asioso_quick_translate_get_document_elements:
     path:     /asioso_quick_translate_get_document_elements
-    defaults: { _controller: QuickTranslateBundle:Document:getDocumentElements }
+    controller: Asioso\QuickTranslateBundle\Controller\DocumentController::getDocumentElementsAction
 
 asioso_quick_translate_check_if_exists:
     path:     /asioso_quick_translate_check_if_exists
-    defaults: { _controller: QuickTranslateBundle:Document:checkIfExists }
+    controller: Asioso\QuickTranslateBundle\Controller\DocumentController::checkIfExistsAction
 
 asioso_quick_translate_get_auth_key:
     path:     /asioso_quick_translate_get_auth_key
-    defaults: { _controller: QuickTranslateBundle:Default:getAuthKey }
+    controller: Asioso\QuickTranslateBundle\Controller\DefaultController::getAuthKeyAction
 

--- a/src/QuickTranslateBundle/Resources/public/js/quick-translate-btn/areablock.js
+++ b/src/QuickTranslateBundle/Resources/public/js/quick-translate-btn/areablock.js
@@ -11,7 +11,6 @@ pimcore.registerNS("pimcore.document.editables.areablock");
 pimcore.document.editables.areablock = Class.create(pimcore.document.editables.areablock, {
 
     namingStrategies: {},
-    namingStrategy: null,
     dialogBoxes: {},
 
     initialize: function (id, name, config, data, inherited) {
@@ -21,9 +20,6 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.editables.a
         this.elements = [];
         this.brickTypeUsageCounter = [];
         this.config = this.parseConfig(config);
-
-        this.initNamingStrategies();
-        var namingStrategy = this.getNamingStrategy();
 
         this.toolbarGlobalVar = this.getType() + "toolbar";
 
@@ -185,30 +181,12 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.editables.a
                             }
                         },
 
-                        onStartDrag: this.createDropZones.bind(this),
-                        afterDragDrop: this.removeDropZones.bind(this),
-                        afterInvalidDrop: this.removeDropZones.bind(this),
-
                         getRepairXY: function () {
                             return this.dragData.repairXY;
                         }
                     });
                 }.bind(this, i));
                 typeButton.render(typeDiv);
-
-
-                // option button
-                if (namingStrategy.supportsCopyPaste()) {
-                    optionsDiv = Ext.get(this.elements[i]).query('.pimcore_block_options[data-name="' + this.name + '"]')[0];
-                    optionsButton = new Ext.Button({
-                        cls: "pimcore_block_button_options",
-                        iconCls: "pimcore_icon_white_copy",
-                        listeners: {
-                            "click": this.optionsClickhandler.bind(this, this.elements[i])
-                        }
-                    });
-                    optionsButton.render(optionsDiv);
-                }
 
                 visibilityDiv = Ext.get(this.elements[i]).query('.pimcore_block_visibility[data-name="' + this.name + '"]')[0];
                 this.visibilityButtons[this.elements[i].key] = new Ext.Button({


### PR DESCRIPTION
I have adjusted the bundle to be compatible to Pimcore X. There have been quite a few breaking changes in Pimcore that broke this bundle:

- `Elements` are called `Editables`
- `PageSnippets` do not support setting `action` or `module` anymore
- Naming strategies are not available anymore. I could not find the particular functionality of this and have removed it. Feedback would be greatly appreciated.
