### PR TITLE
Updated Pimcore 11 Compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     }
   ],
   "require": {
-    "pimcore/pimcore": "^10.0"
+    "pimcore/pimcore": "^11.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/QuickTranslateBundle/Controller/DefaultController.php
+++ b/src/QuickTranslateBundle/Controller/DefaultController.php
@@ -24,7 +24,7 @@ class DefaultController extends FrontendController
         $authKey = WebsiteSetting::getByName("deepl_auth_key") ? WebsiteSetting::getByName("deepl_auth_key")->getData() : null;
         $type = WebsiteSetting::getByName("deepl_type") ? WebsiteSetting::getByName("deepl_type")->getData() : null;
 
-        return JsonResponse::create([
+        return new JsonResponse([
             "authKey" => $authKey,
             "exists" => (($authKey == null || "") ? false : true),
             "type" => $type,
@@ -66,7 +66,7 @@ class DefaultController extends FrontendController
 
         }
 
-        return JsonResponse::create([
+        return new JsonResponse([
             "glossaries" => $glossaries
         ]);
     }

--- a/src/QuickTranslateBundle/Controller/DocumentController.php
+++ b/src/QuickTranslateBundle/Controller/DocumentController.php
@@ -56,12 +56,12 @@ class DocumentController extends FrontendController
             $id = $document->getContentMasterDocumentId() != null ? $document->getContentMasterDocumentId() : $document->getId();
 
             $brickName = $request->get("brickName");
-            $elems = $db->fetchAll("SELECT name, type, data
+            $elems = $db->fetchAllAssociative("SELECT name, type, data
                                         FROM documents_editables
                                         WHERE documentId=" . $document->getId() . " AND (type='input' OR type='textarea' OR type='wysiwyg') AND name LIKE '" . $brickName . "%'");
 
             if ($elems == null && $document->getContentMasterDocumentId() != null) {
-                $elems = $db->fetchAll("SELECT name, type, data
+                $elems = $db->fetchAllAssociative("SELECT name, type, data
                                         FROM documents_editables
                                         WHERE documentId=" . $document->getContentMasterDocumentId() . " AND (type='input' OR type='textarea' OR type='wysiwyg') AND name LIKE '" . $brickName . "%'");
             }
@@ -71,12 +71,12 @@ class DocumentController extends FrontendController
 
         } else {
 
-            $elems = $db->fetchAll("SELECT name, type, data
+            $elems = $db->fetchAllAssociative("SELECT name, type, data
                                         FROM documents_editables
                                         WHERE documentId=" . $request->get("id") . " AND (type='input' OR type='textarea' OR type='wysiwyg')");
 
             if ($elems == null && $document->getContentMasterDocumentId() != null) {
-                $elems = $db->fetchAll("SELECT name, type, data
+                $elems = $db->fetchAllAssociative("SELECT name, type, data
                                         FROM documents_editables
                                         WHERE documentId=" . $document->getContentMasterDocumentId() . " AND (type='input' OR type='textarea' OR type='wysiwyg')");
             }

--- a/src/QuickTranslateBundle/Controller/DocumentController.php
+++ b/src/QuickTranslateBundle/Controller/DocumentController.php
@@ -36,7 +36,7 @@ class DocumentController extends FrontendController
             $exists = false;
         }
 
-        return JsonResponse::create([
+        return new JsonResponse([
             "exists" => $exists
         ]);
 
@@ -91,14 +91,14 @@ class DocumentController extends FrontendController
         }
 
         if(isset($elements)){
-            return JsonResponse::create([
+            return new JsonResponse([
                 "elements" => $elements,
                 "langTo" => ($isBrick ? $langTo : null),
                 "type" => ($isBrick ? $type : null)
             ]);
         }
         else{
-            return JsonResponse::create([
+            return new JsonResponse([
                 // "elements" => $elements[] = (object)[],
                 // "langTo" => ($isBrick ? $langTo : null),
                 // "type" => ($isBrick ? $type : null)
@@ -124,7 +124,7 @@ class DocumentController extends FrontendController
 
         $document->save();
 
-        return JsonResponse::create([
+        return new JsonResponse([
             "success" => true
         ]);
 
@@ -246,7 +246,7 @@ class DocumentController extends FrontendController
                 }
             }
 
-            return JsonResponse::create([
+            return new JsonResponse([
                 'success' => $success,
                 'id' => $document->getId(),
                 'type' => $document->getType(),
@@ -254,7 +254,7 @@ class DocumentController extends FrontendController
             ]);
 
         } else {
-            return JsonResponse::create([
+            return new JsonResponse([
                 'success' => $success,
                 'message' => $errorMessage
             ]);

--- a/src/QuickTranslateBundle/Controller/ObjectController.php
+++ b/src/QuickTranslateBundle/Controller/ObjectController.php
@@ -66,10 +66,10 @@ class ObjectController extends FrontendController
 
             $item->save();
 
-            return JsonResponse::create("true");
+            return new JsonResponse("true");
 
         } catch (\Exception $e) {
-            return JsonResponse::create("false");
+            return new JsonResponse("false");
         }
 
     }

--- a/src/QuickTranslateBundle/QuickTranslateBundle.php
+++ b/src/QuickTranslateBundle/QuickTranslateBundle.php
@@ -70,7 +70,7 @@ class QuickTranslateBundle extends AbstractPimcoreBundle implements PimcoreBundl
     }
 
 
-    public function getNiceName()
+    public function getNiceName() : string
     {
         return 'Asioso - QuickTranslate Bundle';
     }
@@ -80,7 +80,7 @@ class QuickTranslateBundle extends AbstractPimcoreBundle implements PimcoreBundl
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription() : string
     {
         return "";
     }

--- a/src/QuickTranslateBundle/QuickTranslateBundle.php
+++ b/src/QuickTranslateBundle/QuickTranslateBundle.php
@@ -12,16 +12,17 @@ namespace Asioso\QuickTranslateBundle;
 
 use PackageVersions\Versions;
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
-use Pimcore\Extension\Bundle\PimcoreBundleInterface;
+use Pimcore\Extension\Bundle\PimcoreBundleAdminClassicInterface;
+use Pimcore\Extension\Bundle\Traits\BundleAdminClassicTrait;
 use Pimcore\Extension\Bundle\Traits\PackageVersionTrait;
 
-class QuickTranslateBundle extends AbstractPimcoreBundle implements PimcoreBundleInterface
+class QuickTranslateBundle extends AbstractPimcoreBundle implements PimcoreBundleAdminClassicInterface
 {
-
+    use BundleAdminClassicTrait;
     use PackageVersionTrait;
     const PACKAGE_NAME = 'asioso/pimcore-quicktranslate-module';
 
-    public function getJsPaths()
+    public function getJsPaths() : array
     {
         return [
             'https://code.jquery.com/jquery-3.6.0.min.js',
@@ -39,7 +40,7 @@ class QuickTranslateBundle extends AbstractPimcoreBundle implements PimcoreBundl
         ];
     }
 
-    public function getEditmodeJsPaths()
+    public function getEditmodeJsPaths() : array
     {
 
         return [
@@ -55,14 +56,14 @@ class QuickTranslateBundle extends AbstractPimcoreBundle implements PimcoreBundl
 
     }
 
-    public function getEditmodeCssPaths()
+    public function getEditmodeCssPaths() : array
     {
         return [
             '/bundles/quicktranslate/css/quick-translate.css'
         ];
     }
 
-    public function getCssPaths()
+    public function getCssPaths() : array
     {
         return [
             '/bundles/quicktranslate/css/quick-translate.css'

--- a/src/QuickTranslateBundle/Resources/public/js/pimcore/startup.js
+++ b/src/QuickTranslateBundle/Resources/public/js/pimcore/startup.js
@@ -9,21 +9,23 @@
 
 pimcore.registerNS("pimcore.plugin.asiosoQuickTranslateBundle");
 
-pimcore.plugin.asiosoQuickTranslateBundle = Class.create(pimcore.plugin.admin, {
+pimcore.plugin.asiosoQuickTranslateBundle = Class.create({
     getClassName: function () {
         return "pimcore.plugin.asiosoQuickTranslateBundle";
     },
 
     initialize: function () {
-        pimcore.plugin.broker.registerPlugin(this);
+        document.addEventListener(pimcore.events.postOpenObject, this.postOpenObject.bind(this));
+        document.addEventListener(pimcore.events.postOpenDocument, this.postOpenDocument.bind(this));
     },
 
     pimcoreReady: function (params, broker) {
 
     },
 
-    postOpenObject: function (object, type) {
+    postOpenObject: function (event) {
         /* add quickTranslate icon to objects with localizedfields */
+        const { detail: { object, type } } = event;
         if (type === "object") {
             if (object.data.data.hasOwnProperty("localizedfields")) {
                 object.tabbar.add(new pimcore.element.quickTranslateObjectBtn(object, "object").getLayout());
@@ -45,8 +47,9 @@ pimcore.plugin.asiosoQuickTranslateBundle = Class.create(pimcore.plugin.admin, {
     },
 
 
-    postOpenDocument: function (document, type) {
+    postOpenDocument: function (event) {
         /* add quicktranslate button to specific document type */
+        const { detail: { document, type } } = event;
         if (type == "page" || type == "snippet" || type == "printpage") {
 
             /* checks if document language is supported by deepl and ads the button if it is */
@@ -55,7 +58,7 @@ pimcore.plugin.asiosoQuickTranslateBundle = Class.create(pimcore.plugin.admin, {
                     this.docBtn(document);
                 }*/
             } else {
-                if (isDeeplLanguage(document.data.properties["language"]["data"])) {
+                if (document.data.properties["language"] && isDeeplLanguage(document.data.properties["language"]["data"])) {
                     this.docBtn(document);
                 }
             }

--- a/src/QuickTranslateBundle/Resources/public/js/quick-translate-btn/quickTranslateDocument.js
+++ b/src/QuickTranslateBundle/Resources/public/js/quick-translate-btn/quickTranslateDocument.js
@@ -14,7 +14,7 @@ function quickTranslateDocument(documentTranslate) {
     var websiteLanguages = pimcore.settings.websiteLanguages;
     var selectContent = "";
     for (var i = 0; i < websiteLanguages.length; i++) {
-        if (documentTranslate.data.properties["language"]["data"] != websiteLanguages[i] && isDeeplLanguage(websiteLanguages[i])) {
+        if (documentTranslate.data.properties["language"] && documentTranslate.data.properties["language"]["data"] != websiteLanguages[i] && isDeeplLanguage(websiteLanguages[i])) {
             selectContent = pimcore.available_languages[websiteLanguages[i]] + " [" + websiteLanguages[i] + "]";
             languagestore.push([websiteLanguages[i], selectContent]);
         }

--- a/src/QuickTranslateBundle/Resources/public/js/quick-translate-btn/quickTranslateObjectBtn.js
+++ b/src/QuickTranslateBundle/Resources/public/js/quick-translate-btn/quickTranslateObjectBtn.js
@@ -146,7 +146,8 @@ pimcore.element.quickTranslateObjectBtn = Class.create({
                                                     xmlStr += str;
 
                                                 } else if (typeof data[field] === "string") {
-                                                    var str = "<" + field + " quick-t-tag='" + field + "'>" + data[field] + "</" + field + ">";
+                                                    var escaped = data[field].replace(/>/g, "(gT)").replace(/</g, "(lT)");
+                                                    var str = "<" + field + " quick-t-tag='" + field + "'>" + escaped + "</" + field + ">";
                                                     xmlStr += str;
                                                 }
                                             }

--- a/src/QuickTranslateBundle/Resources/public/js/utilities/xmlRegReplace.js
+++ b/src/QuickTranslateBundle/Resources/public/js/utilities/xmlRegReplace.js
@@ -13,7 +13,10 @@ function xmlRegReplace(xml, replaceBack = false) {
         return xml.replace(/\(AmPnBsP\);/g, "&nbsp;")
             .replace(/\(br\)/g, '<br />')
             .replace(/AmP;/g, "&amp;")
-            .replace(/\(HaShTaG\)/g, "#");
+            .replace(/\(HaShTaG\)/g, "#")
+            .replace(/\(gT\)/g, ">")
+            .replace(/\(lT\)/g, "<")
+            .replace(/\(sC\)/g, ";");
     }
 
     return xml.replace(/\s\s+/g, "")
@@ -22,5 +25,6 @@ function xmlRegReplace(xml, replaceBack = false) {
         .replace(/<br( \/)?>/g, "(br)")
         .replace(/&amp;/g, "AmP;")
         .replace(/ & /g, "AmP;")
-        .replace(/#/g, "(HaShTaG)");
+        .replace(/#/g, "(HaShTaG)")
+        .replace(/;/g, "(sC)");
 };


### PR DESCRIPTION
Fixed following error on Pimcore 11
`Compile Error: Declaration of Asioso\QuickTranslateBundle\QuickTranslateBundle::getDescription() must be compatible
   with Pimcore\Extension\Bundle\AbstractPimcoreBundle::getNiceName(): string`
`Compile Error: Declaration of Asioso\QuickTranslateBundle\QuickTranslateBundle::getDescription() must be compatible
   with Pimcore\Extension\Bundle\AbstractPimcoreBundle::getDescription(): string`